### PR TITLE
Update index-Colab.ipynb

### DIFF
--- a/index-Colab.ipynb
+++ b/index-Colab.ipynb
@@ -20,7 +20,7 @@
    "outputs": [],
    "source": [
     "# Install PlantCV and required dependencies\n",
-    "%pip install \"altair>=5\" ipympl plantcv\n",
+    "%pip install \"altair>=5\" plantcv\n",
     "\n",
     "# Give access and mount your Google Drive (need a Google Account)\n",
     "# Change path to directory you wish output files to be saved to.\n",
@@ -41,7 +41,11 @@
    "metadata": {},
    "source": [
     "### DEV NOTE:\n",
-    "If the tutorial you are working on requires the use of a special image type that isn’t .jpg/.png/.tiff or multiple images then you will need to use the code chunk below to clone the GitHub repo to the user’s Google Drive (MyDrive)."
+    "Copy the next code cell if the tutorial you are working on meets any of the following:\n",
+    "* use of a file type that is not JPG/PNG/TIFF\n",
+    "* requires a batch of images\n",
+    "\n",
+    "Users will need to clone the repository to their Google Drive and change the working directory to the cloned repository. This ensures none of the file paths need to be altered in the tutorial notebook."
    ]
   },
   {
@@ -56,7 +60,9 @@
     "# Print the contents of your drive to confirm it worked \n",
     "!ls \n",
     "# Clone the workshop's repository to your Google Drive \n",
-    "!git clone https://github.com/danforthcenter/replace-with-tutorial-name.git"
+    "!git clone https://github.com/danforthcenter/replace-with-tutorial-name.git\n",
+    "# Change directory to the cloned repository\n",
+    "%cd replace-with-tutorial-name"
    ]
   },
   {
@@ -79,8 +85,8 @@
    "outputs": [],
    "source": [
     "# Set the notebook display method\n",
-    "# If widget is not working, then change to inline\n",
-    "%matplotlib widget\n",
+    "# Display method is set to inline so that figures are displayed in the notebook\n",
+    "%matplotlib inline\n",
     "# Import libraries\n",
     "from plantcv import plantcv as pcv\n",
     "from plantcv.parallel import WorkflowInputs\n",


### PR DESCRIPTION
- Removed 'ipympl' from install and changed from 'widget' to 'inline' for plotting figures 
- Changed markdown language for describing when a tutorial might need to have the repository cloned 
- Changing the directory to the tutorial once cloned will help preserve the file paths in the tutorial (hopefully)